### PR TITLE
Allow certain calc() operations to be parsed according to the spec

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -104,6 +104,22 @@ module.exports = function(input) {
       pos = next + 2;
       code = value.charCodeAt(pos);
 
+      // Operation within calc
+    } else if (
+      (code === slash || code === star) &&
+      parent &&
+      parent.type === "function" &&
+      parent.value === "calc"
+    ) {
+      token = value[pos];
+      tokens.push({
+        type: "word",
+        sourceIndex: pos - before.length,
+        value: token
+      });
+      pos += 1;
+      code = value.charCodeAt(pos);
+
       // Dividers
     } else if (code === slash || code === comma || code === colon) {
       token = value[pos];
@@ -224,6 +240,8 @@ module.exports = function(input) {
           code === colon ||
           code === slash ||
           code === openParentheses ||
+          (code === star && token.type === "function") ||
+          (code === slash && token.type === "function") ||
           (code === closeParentheses && balanced)
         )
       );

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -240,8 +240,13 @@ module.exports = function(input) {
           code === colon ||
           code === slash ||
           code === openParentheses ||
-          (code === star && token.type === "function") ||
-          (code === slash && token.type === "function") ||
+          (code === star &&
+            parent &&
+            parent.type === "function" &&
+            parent.value === "calc") ||
+          (code === slash &&
+            parent.type === "function" &&
+            parent.value === "calc") ||
           (code === closeParentheses && balanced)
         )
       );

--- a/test/parse.js
+++ b/test/parse.js
@@ -453,6 +453,116 @@ var tests = [
     ]
   },
   {
+    message: "should correctly parse spaces",
+    fixture: "calc(1 + 2)",
+    expected: [
+      {
+        type: "function",
+        sourceIndex: 0,
+        value: "calc",
+        before: "",
+        after: "",
+        nodes: [
+          {
+            type: "word",
+            sourceIndex: 5,
+            value: "1"
+          },
+          {
+            type: "space",
+            sourceIndex: 6,
+            value: " "
+          },
+          {
+            type: "word",
+            sourceIndex: 7,
+            value: "+"
+          },
+          {
+            type: "space",
+            sourceIndex: 8,
+            value: " "
+          },
+          {
+            type: "word",
+            sourceIndex: 9,
+            value: "2"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    message: "should correctly parse multiplication with spaces",
+    fixture: "calc(1 * 2)",
+    expected: [
+      {
+        type: "function",
+        sourceIndex: 0,
+        value: "calc",
+        before: "",
+        after: "",
+        nodes: [
+          {
+            type: "word",
+            sourceIndex: 5,
+            value: "1"
+          },
+          {
+            type: "space",
+            sourceIndex: 6,
+            value: " "
+          },
+          {
+            type: "word",
+            sourceIndex: 7,
+            value: "*"
+          },
+          {
+            type: "space",
+            sourceIndex: 8,
+            value: " "
+          },
+          {
+            type: "word",
+            sourceIndex: 9,
+            value: "2"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    message: "should correctly parse multiplication without spaces",
+    fixture: "calc(1*2)",
+    expected: [
+      {
+        type: "function",
+        sourceIndex: 0,
+        value: "calc",
+        before: "",
+        after: "",
+        nodes: [
+          {
+            type: "word",
+            sourceIndex: 5,
+            value: "1"
+          },
+          {
+            type: "word",
+            sourceIndex: 6,
+            value: "*"
+          },
+          {
+            type: "word",
+            sourceIndex: 7,
+            value: "2"
+          }
+        ]
+      }
+    ]
+  },
+  {
     message: "should correctly process nested calc functions",
     fixture: "calc(((768px - 100vw) / 2) - 15px)",
     expected: [


### PR DESCRIPTION
There is a minor discrepancy with the spec with regards to calc syntax:
```
calc(1+2) //invalid syntax
calc(1 + 2) // valid syntax
calc(1*2) // valid syntax
calc(1 * 2) // valid syntax
```

Currently `postcss-value-parser` does not tokenize correctly `calc` function without spaces for the multiplication and division operations.

Per [specification](https://drafts.csswg.org/css-values-3/#calc-syntax):

> In addition, white space is required on both sides of the + and - operators. (The * and / operaters can be used without white space around them.)

This PR addressed the issue allowing the right tokenization of calc functions such as `calc(1*2)`

fixes https://github.com/TrySound/postcss-value-parser/issues/33