### PR TITLE
fix: invalidate values starting with 'e' + digit

### DIFF
--- a/lib/unit.js
+++ b/lib/unit.js
@@ -18,7 +18,7 @@ module.exports = function(value) {
     if (code >= 48 && code <= 57) {
       containsNumber = true;
     } else if (code === exp || code === EXP) {
-      if (sciPos > -1) {
+      if (sciPos > -1 || pos === 0) {
         break;
       }
       sciPos = pos;

--- a/test/unit.js
+++ b/test/unit.js
@@ -53,6 +53,10 @@ var tests = [
   {
     fixture: "e",
     expected: false
+  },
+  {
+    fixture: "e1",
+    expected: false
   }
 ];
 


### PR DESCRIPTION
Fixes #48

Prevents values starting with 'e' + digit from being considered numbers.

Currently, if the first character is an 'e' and it's followed by a digit, `containsNumber` will be set to `true`.

This results in values that aren't units at all, being processed as such. One such example is animation names which, after hashing can be broken. 
The package `cssnano/postcss-convert-values`, runs this line using the return value from postcss-value-parse here https://github.com/cssnano/cssnano/blob/master/packages/postcss-convert-values/src/index.js#L26

An input of e6abc would be converted to NaNabc.

The issue causes animation bugs in which a rule like:
```
el {
  animation: e1abc 1s linear
}
```

would be converted to:

```
el {
  animation: NaNabc 1s linear
}
```

The animation name reference in the keyframes declaration would remain the original one, breaking the animation.