### PR TITLE
Improve type declarations

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -85,7 +85,7 @@ declare namespace postcssValueParser {
      * @param node The node to stringify
      * @returns The serialized CSS representation of the node
      */
-    (nodes: Node): string;
+    (nodes: Node): string | undefined;
   }
 
   interface WalkCallback {
@@ -95,7 +95,7 @@ declare namespace postcssValueParser {
      * @param nodes The series of parsed nodes
      * @returns Returning `false` will prevent traversal of descendant nodes (only applies if `bubble` was set to `true` in the `walk()` call)
      */
-    (node: Node, index: number, nodes: Node[]): void | false;
+    (node: Node, index: number, nodes: Node[]): void | boolean;
   }
 
   /**


### PR DESCRIPTION
* Indicate that a CustomStringCallback can return undefined to
  indicate that no custom behavior should be applied for that node.

* Allow WalkCallback to return false. Otherwise, a callback that may
  or may not prevent further traversal can't be expressed in
  TypeScript, since it doesn't allow a function to only return a value
  some of the time.