### PR TITLE
docs: Explain parsing numbers with no digits after dot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ If the `quantity` argument cannot be parsed as a number, returns `false`.
 the unit. Instead, you should pass it single quantities only. Parse `1px solid black`, then pass it
 the stringified `1px` node (a `word` node) to parse the number and unit.
 
+Quantities of the form `2.rem` (no digits after the dot) are not valid CSS. In this case, instead of
+throwing an error, `unit()` returns the dot as part of the unit:
+
+```js
+// Given 2.rem 
+{
+  number: '2',
+  unit: '.rem'
+}
+```
+
 ### valueParser.stringify(nodes[, custom])
 
 Stringifies a node or array of nodes.


### PR DESCRIPTION
I want to add some explanations about `unit()` as I found surprising that with numbers such as `10.` the unit contains the dot. [These tests](https://github.com/TrySound/postcss-value-parser/blob/d83cd7fecf19c49a7fa75cd8b2124bfad13ec9d3/test/unit.js#L15) made me believe it is intentional. Then I found out that according to the official CSS spec, omitting the `0` after the dot is [forbidden](https://drafts.csswg.org/css-values-3/#numbers), so I hope I explain the intention behind this behaviour correctly.