### PR TITLE
feat: Report end indices for nodes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,9 +1,14 @@
 declare namespace postcssValueParser {
   interface BaseNode {
     /**
-     * The offset inside the CSS value at which the node starts
+     * The offset, inclusive, inside the CSS value at which the node starts.
      */
     sourceIndex: number;
+
+    /**
+     * The offset, exclusive, inside the CSS value at which the node ends.
+     */
+    sourceEndIndex: number;
 
     /**
      * The node's characteristic value

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tape": "^4.10.2"
   },
   "scripts": {
-    "lint:prettier": "prettier '**/*.js' '**/*.ts' --list-different",
+    "lint:prettier": "prettier \"**/*.js\" \"**/*.ts\" --list-different",
     "lint:js": "eslint . --cache",
     "lint": "yarn lint:js && yarn lint:prettier",
     "pretest": "yarn lint",

--- a/test/index.js
+++ b/test/index.js
@@ -144,7 +144,7 @@ test("ValueParser", function(tp) {
           after: "",
           nodes: []
         },
-        { type: "space", sourceIndex: 5, value: " " },
+        { type: "space", sourceIndex: 5, sourceEndIndex: 6, value: " " },
         {
           type: "word",
           sourceIndex: 6,

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 0,
+          sourceEndIndex: 5,
           value: "fn",
           before: " ",
           after: "",
@@ -46,6 +47,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 6,
+          sourceEndIndex: 17,
           value: "fn2",
           before: " ",
           after: "",
@@ -53,6 +55,7 @@ test("ValueParser", function(tp) {
             {
               type: "function",
               sourceIndex: 11,
+              sourceEndIndex: 16,
               value: "fn3",
               before: "",
               after: "",
@@ -63,6 +66,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 11,
+          sourceEndIndex: 16,
           value: "fn3",
           before: "",
           after: "",
@@ -90,6 +94,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 0,
+          sourceEndIndex: 5,
           value: "fn",
           before: " ",
           after: "",
@@ -98,6 +103,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 6,
+          sourceEndIndex: 17,
           value: "fn2",
           before: " ",
           after: "",
@@ -105,6 +111,7 @@ test("ValueParser", function(tp) {
             {
               type: "function",
               sourceIndex: 11,
+              sourceEndIndex: 16,
               value: "fn3",
               before: "",
               after: "",
@@ -131,6 +138,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 0,
+          sourceEndIndex: 5,
           value: "fn",
           before: " ",
           after: "",
@@ -140,6 +148,7 @@ test("ValueParser", function(tp) {
         {
           type: "word",
           sourceIndex: 6,
+          sourceEndIndex: 17,
           value: "fn2",
           before: " ",
           after: "",
@@ -147,6 +156,7 @@ test("ValueParser", function(tp) {
             {
               type: "function",
               sourceIndex: 11,
+              sourceEndIndex: 16,
               value: "fn3",
               before: "",
               after: "",
@@ -172,6 +182,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 5,
+          sourceEndIndex: 10,
           value: "fn3",
           before: "",
           after: "",
@@ -180,6 +191,7 @@ test("ValueParser", function(tp) {
         {
           type: "function",
           sourceIndex: 0,
+          sourceEndIndex: 11,
           value: "fn2",
           before: " ",
           after: "",
@@ -187,6 +199,7 @@ test("ValueParser", function(tp) {
             {
               type: "function",
               sourceIndex: 5,
+              sourceEndIndex: 10,
               value: "fn3",
               before: "",
               after: "",

--- a/test/parse.js
+++ b/test/parse.js
@@ -1211,7 +1211,14 @@ var tests = [
         value: "url",
         before: "",
         after: "",
-        nodes: [{ type: "word", sourceIndex: 4, value: "foo/bar.jpg" }]
+        nodes: [
+          {
+            type: "word",
+            sourceIndex: 4,
+            sourceEndIndex: 15,
+            value: "foo/bar.jpg"
+          }
+        ]
       },
       {
         type: "div",

--- a/test/parse.js
+++ b/test/parse.js
@@ -80,7 +80,7 @@ var tests = [
         value: "",
         before: " ",
         after: " ",
-        nodes: [{ type: "word", sourceIndex: 2, value: "|" }]
+        nodes: [{ type: "word", sourceIndex: 2, sourceEndIndex: 3, value: "|" }]
       }
     ]
   },
@@ -221,7 +221,7 @@ var tests = [
         sourceIndex: 0,
         sourceEndIndex: 3,
         value: ",",
-        before: "",
+        before: " ",
         after: " "
       }
     ]
@@ -1005,7 +1005,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
-        sourceEndIndex: 40,
+        sourceEndIndex: 39,
         value: "url",
         before: " ",
         after: " ",
@@ -1013,7 +1013,7 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
-            sourceEndIndex: 38,
+            sourceEndIndex: 37,
             value: "http://website.com/assets\\)_test"
           }
         ]

--- a/test/parse.js
+++ b/test/parse.js
@@ -10,25 +10,31 @@ var tests = [
   {
     message: "should process escaped parentheses (open)",
     fixture: "\\(",
-    expected: [{ type: "word", sourceIndex: 0, value: "\\(" }]
+    expected: [
+      { type: "word", sourceIndex: 0, sourceEndIndex: 2, value: "\\(" }
+    ]
   },
   {
     message: "should process escaped parentheses (close)",
     fixture: "\\)",
-    expected: [{ type: "word", sourceIndex: 0, value: "\\)" }]
+    expected: [
+      { type: "word", sourceIndex: 0, sourceEndIndex: 2, value: "\\)" }
+    ]
   },
   {
     message: "should process escaped parentheses (both)",
     fixture: "\\(\\)",
-    expected: [{ type: "word", sourceIndex: 0, value: "\\(\\)" }]
+    expected: [
+      { type: "word", sourceIndex: 0, sourceEndIndex: 4, value: "\\(\\)" }
+    ]
   },
   {
     message: "should process escaped parentheses (both)",
     fixture: "\\( \\)",
     expected: [
-      { type: "word", sourceIndex: 0, value: "\\(" },
-      { type: "space", sourceIndex: 2, value: " " },
-      { type: "word", sourceIndex: 3, value: "\\)" }
+      { type: "word", sourceIndex: 0, sourceEndIndex: 2, value: "\\(" },
+      { type: "space", sourceIndex: 2, sourceEndIndex: 3, value: " " },
+      { type: "word", sourceIndex: 3, sourceEndIndex: 5, value: "\\)" }
     ]
   },
   {
@@ -38,13 +44,14 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 2,
         value: "",
         before: "",
         after: "",
         nodes: []
       },
-      { type: "space", sourceIndex: 2, value: " " },
-      { type: "word", sourceIndex: 3, value: ")wo)rd)" }
+      { type: "space", sourceIndex: 2, sourceEndIndex: 3, value: " " },
+      { type: "word", sourceIndex: 3, sourceEndIndex: 10, value: ")wo)rd)" }
     ]
   },
   {
@@ -54,6 +61,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 3,
         value: "",
         before: " ",
         after: "",
@@ -68,6 +76,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 5,
         value: "",
         before: " ",
         after: " ",
@@ -82,6 +91,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 6,
         value: "name",
         before: "",
         after: "",
@@ -96,6 +106,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 6,
         value: "",
         before: "",
         after: "",
@@ -103,6 +114,7 @@ var tests = [
           {
             type: "function",
             sourceIndex: 1,
+            sourceEndIndex: 5,
             value: "",
             before: "",
             after: "",
@@ -110,6 +122,7 @@ var tests = [
               {
                 type: "function",
                 sourceIndex: 2,
+                sourceEndIndex: 4,
                 value: "",
                 before: "",
                 after: "",
@@ -128,6 +141,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 13,
         value: "",
         before: " ",
         after: "",
@@ -135,6 +149,7 @@ var tests = [
           {
             type: "function",
             sourceIndex: 2,
+            sourceEndIndex: 12,
             value: "calc",
             before: "",
             after: " ",
@@ -142,6 +157,7 @@ var tests = [
               {
                 type: "function",
                 sourceIndex: 7,
+                sourceEndIndex: 10,
                 value: "",
                 before: " ",
                 after: "",
@@ -151,35 +167,63 @@ var tests = [
           }
         ]
       },
-      { type: "word", sourceIndex: 13, value: "word" }
+      { type: "word", sourceIndex: 13, sourceEndIndex: 17, value: "word" }
     ]
   },
   {
     message: "should process divider (/)",
     fixture: "/",
     expected: [
-      { type: "div", sourceIndex: 0, value: "/", before: "", after: "" }
+      {
+        type: "div",
+        sourceIndex: 0,
+        sourceEndIndex: 1,
+        value: "/",
+        before: "",
+        after: ""
+      }
     ]
   },
   {
     message: "should process divider (:)",
     fixture: ":",
     expected: [
-      { type: "div", sourceIndex: 0, value: ":", before: "", after: "" }
+      {
+        type: "div",
+        sourceIndex: 0,
+        sourceEndIndex: 1,
+        value: ":",
+        before: "",
+        after: ""
+      }
     ]
   },
   {
     message: "should process divider (,)",
     fixture: ",",
     expected: [
-      { type: "div", sourceIndex: 0, value: ",", before: "", after: "" }
+      {
+        type: "div",
+        sourceIndex: 0,
+        sourceEndIndex: 1,
+        value: ",",
+        before: "",
+        after: ""
+      }
     ]
   },
   {
     message: "should process complex divider",
     fixture: " , ",
     expected: [
-      { type: "div", sourceIndex: 0, value: ",", before: " ", after: " " }
+      {
+        type: "div",
+        sourceIndex: 0,
+        sourceEndIndex: 3,
+        value: ",",
+        before: "",
+        after: " "
+      }
     ]
   },
   {
@@ -189,6 +233,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 5,
         value: "",
         before: " ",
         after: " ",
@@ -196,6 +241,7 @@ var tests = [
           {
             type: "div",
             sourceIndex: 2,
+            sourceEndIndex: 3,
             value: ",",
             before: "",
             after: ""
@@ -211,49 +257,97 @@ var tests = [
       {
         type: "div",
         sourceIndex: 0,
+        sourceEndIndex: 3,
         value: ",",
         before: " ",
         after: " "
       },
-      { type: "div", sourceIndex: 3, value: ":", before: "", after: " " }
+      {
+        type: "div",
+        sourceIndex: 3,
+        sourceEndIndex: 5,
+        value: ":",
+        before: "",
+        after: " "
+      }
     ]
   },
   {
     message: 'should process empty quoted strings (")',
     fixture: '""',
-    expected: [{ type: "string", sourceIndex: 0, value: "", quote: '"' }]
+    expected: [
+      {
+        type: "string",
+        sourceIndex: 0,
+        sourceEndIndex: 2,
+        value: "",
+        quote: '"'
+      }
+    ]
   },
   {
     message: "should process empty quoted strings (')",
     fixture: "''",
-    expected: [{ type: "string", sourceIndex: 0, value: "", quote: "'" }]
+    expected: [
+      {
+        type: "string",
+        sourceIndex: 0,
+        sourceEndIndex: 2,
+        value: "",
+        quote: "'"
+      }
+    ]
   },
   {
     message: "should process escaped quotes (')",
     fixture: "'word\\'word'",
     expected: [
-      { type: "string", sourceIndex: 0, value: "word\\'word", quote: "'" }
+      {
+        type: "string",
+        sourceIndex: 0,
+        sourceEndIndex: 12,
+        value: "word\\'word",
+        quote: "'"
+      }
     ]
   },
   {
     message: "should process escaped quotes (')",
     fixture: '"word\\"word"',
     expected: [
-      { type: "string", sourceIndex: 0, value: 'word\\"word', quote: '"' }
+      {
+        type: "string",
+        sourceIndex: 0,
+        sourceEndIndex: 12,
+        value: 'word\\"word',
+        quote: '"'
+      }
     ]
   },
   {
     message: "should process single quotes inside double quotes (')",
     fixture: '"word\'word"',
     expected: [
-      { type: "string", sourceIndex: 0, value: "word'word", quote: '"' }
+      {
+        type: "string",
+        sourceIndex: 0,
+        sourceEndIndex: 11,
+        value: "word'word",
+        quote: '"'
+      }
     ]
   },
   {
     message: "should process double quotes inside single quotes (')",
     fixture: "'word\"word'",
     expected: [
-      { type: "string", sourceIndex: 0, value: 'word"word', quote: "'" }
+      {
+        type: "string",
+        sourceIndex: 0,
+        sourceEndIndex: 11,
+        value: 'word"word',
+        quote: "'"
+      }
     ]
   },
   {
@@ -263,6 +357,7 @@ var tests = [
       {
         type: "string",
         sourceIndex: 0,
+        sourceEndIndex: 5,
         value: "word",
         quote: '"',
         unclosed: true
@@ -276,6 +371,7 @@ var tests = [
       {
         type: "string",
         sourceIndex: 0,
+        sourceEndIndex: 6,
         value: "word\\",
         quote: '"',
         unclosed: true
@@ -285,33 +381,58 @@ var tests = [
   {
     message: "should process quoted strings",
     fixture: '"string"',
-    expected: [{ type: "string", sourceIndex: 0, value: "string", quote: '"' }]
+    expected: [
+      {
+        type: "string",
+        sourceIndex: 0,
+        sourceEndIndex: 8,
+        value: "string",
+        quote: '"'
+      }
+    ]
   },
   {
     message: "should process quoted strings and words",
     fixture: 'word1"string"word2',
     expected: [
-      { type: "word", sourceIndex: 0, value: "word1" },
-      { type: "string", sourceIndex: 5, value: "string", quote: '"' },
-      { type: "word", sourceIndex: 13, value: "word2" }
+      { type: "word", sourceIndex: 0, sourceEndIndex: 5, value: "word1" },
+      {
+        type: "string",
+        sourceIndex: 5,
+        sourceEndIndex: 13,
+        value: "string",
+        quote: '"'
+      },
+      { type: "word", sourceIndex: 13, sourceEndIndex: 18, value: "word2" }
     ]
   },
   {
     message: "should process quoted strings and spaces",
     fixture: ' "string" ',
     expected: [
-      { type: "space", sourceIndex: 0, value: " " },
-      { type: "string", sourceIndex: 1, value: "string", quote: '"' },
-      { type: "space", sourceIndex: 9, value: " " }
+      { type: "space", sourceIndex: 0, sourceEndIndex: 1, value: " " },
+      {
+        type: "string",
+        sourceIndex: 1,
+        sourceEndIndex: 9,
+        value: "string",
+        quote: '"'
+      },
+      { type: "space", sourceIndex: 9, sourceEndIndex: 10, value: " " }
     ]
   },
   {
     message: "should process escaped symbols as words",
     fixture: " \\\"word\\'\\ \\\t ",
     expected: [
-      { type: "space", sourceIndex: 0, value: " " },
-      { type: "word", sourceIndex: 1, value: "\\\"word\\'\\ \\\t" },
-      { type: "space", sourceIndex: 13, value: " " }
+      { type: "space", sourceIndex: 0, sourceEndIndex: 1, value: " " },
+      {
+        type: "word",
+        sourceIndex: 1,
+        sourceEndIndex: 13,
+        value: "\\\"word\\'\\ \\\t"
+      },
+      { type: "space", sourceIndex: 13, sourceEndIndex: 14, value: " " }
     ]
   },
   {
@@ -319,32 +440,41 @@ var tests = [
     fixture:
       "bold italic 12px \t /3 'Open Sans', Arial, \"Helvetica Neue\", sans-serif",
     expected: [
-      { type: "word", sourceIndex: 0, value: "bold" },
-      { type: "space", sourceIndex: 4, value: " " },
-      { type: "word", sourceIndex: 5, value: "italic" },
-      { type: "space", sourceIndex: 11, value: " " },
-      { type: "word", sourceIndex: 12, value: "12px" },
+      { type: "word", sourceIndex: 0, sourceEndIndex: 4, value: "bold" },
+      { type: "space", sourceIndex: 4, sourceEndIndex: 5, value: " " },
+      { type: "word", sourceIndex: 5, sourceEndIndex: 11, value: "italic" },
+      { type: "space", sourceIndex: 11, sourceEndIndex: 12, value: " " },
+      { type: "word", sourceIndex: 12, sourceEndIndex: 16, value: "12px" },
       {
         type: "div",
         sourceIndex: 16,
+        sourceEndIndex: 20,
         value: "/",
         before: " \t ",
         after: ""
       },
-      { type: "word", sourceIndex: 20, value: "3" },
-      { type: "space", sourceIndex: 21, value: " " },
-      { type: "string", sourceIndex: 22, value: "Open Sans", quote: "'" },
+      { type: "word", sourceIndex: 20, sourceEndIndex: 21, value: "3" },
+      { type: "space", sourceIndex: 21, sourceEndIndex: 22, value: " " },
+      {
+        type: "string",
+        sourceIndex: 22,
+        sourceEndIndex: 33,
+        value: "Open Sans",
+        quote: "'"
+      },
       {
         type: "div",
         sourceIndex: 33,
+        sourceEndIndex: 35,
         value: ",",
         before: "",
         after: " "
       },
-      { type: "word", sourceIndex: 35, value: "Arial" },
+      { type: "word", sourceIndex: 35, sourceEndIndex: 40, value: "Arial" },
       {
         type: "div",
         sourceIndex: 40,
+        sourceEndIndex: 42,
         value: ",",
         before: "",
         after: " "
@@ -352,17 +482,19 @@ var tests = [
       {
         type: "string",
         sourceIndex: 42,
+        sourceEndIndex: 58,
         value: "Helvetica Neue",
         quote: '"'
       },
       {
         type: "div",
         sourceIndex: 58,
+        sourceEndIndex: 60,
         value: ",",
         before: "",
         after: " "
       },
-      { type: "word", sourceIndex: 60, value: "sans-serif" }
+      { type: "word", sourceIndex: 60, sourceEndIndex: 70, value: "sans-serif" }
     ]
   },
   {
@@ -372,27 +504,30 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 20,
         value: "rgba",
         before: " ",
         after: " ",
         nodes: [
-          { type: "word", sourceIndex: 6, value: "29" },
+          { type: "word", sourceIndex: 6, sourceEndIndex: 8, value: "29" },
           {
             type: "div",
             sourceIndex: 8,
+            sourceEndIndex: 10,
             value: ",",
             before: "",
             after: " "
           },
-          { type: "word", sourceIndex: 10, value: "439" },
+          { type: "word", sourceIndex: 10, sourceEndIndex: 13, value: "439" },
           {
             type: "div",
             sourceIndex: 13,
+            sourceEndIndex: 16,
             value: ",",
             before: " ",
             after: " "
           },
-          { type: "word", sourceIndex: 16, value: "29" }
+          { type: "word", sourceIndex: 16, sourceEndIndex: 18, value: "29" }
         ]
       }
     ]
@@ -404,10 +539,18 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 22,
         value: "url",
         before: " ",
         after: " ",
-        nodes: [{ type: "word", sourceIndex: 5, value: "/gfx/img/bg.jpg" }]
+        nodes: [
+          {
+            type: "word",
+            sourceIndex: 5,
+            sourceEndIndex: 20,
+            value: "/gfx/img/bg.jpg"
+          }
+        ]
       }
     ]
   },
@@ -418,13 +561,19 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 21,
         value: "url",
         before: " ",
         after: "",
         unclosed: true,
         nodes: [
-          { type: "word", sourceIndex: 5, value: "/gfx/img/bg.jpg" },
-          { type: "space", sourceIndex: 20, value: " " }
+          {
+            type: "word",
+            sourceIndex: 5,
+            sourceEndIndex: 20,
+            value: "/gfx/img/bg.jpg"
+          },
+          { type: "space", sourceIndex: 20, sourceEndIndex: 21, value: " " }
         ]
       }
     ]
@@ -436,6 +585,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 30,
         value: "url",
         before: " ",
         after: " ",
@@ -443,11 +593,12 @@ var tests = [
           {
             type: "string",
             sourceIndex: 5,
+            sourceEndIndex: 22,
             quote: '"',
             value: "/gfx/img/bg.jpg"
           },
-          { type: "space", sourceIndex: 22, value: " " },
-          { type: "word", sourceIndex: 23, value: "hello" }
+          { type: "space", sourceIndex: 22, sourceEndIndex: 23, value: " " },
+          { type: "word", sourceIndex: 23, sourceEndIndex: 28, value: "hello" }
         ]
       }
     ]
@@ -459,6 +610,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 11,
         value: "calc",
         before: "",
         after: "",
@@ -466,26 +618,31 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 6,
             value: "1"
           },
           {
             type: "space",
             sourceIndex: 6,
+            sourceEndIndex: 7,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 7,
+            sourceEndIndex: 8,
             value: "+"
           },
           {
             type: "space",
             sourceIndex: 8,
+            sourceEndIndex: 9,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 9,
+            sourceEndIndex: 10,
             value: "2"
           }
         ]
@@ -499,6 +656,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 11,
         value: "calc",
         before: "",
         after: "",
@@ -506,26 +664,31 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 6,
             value: "1"
           },
           {
             type: "space",
             sourceIndex: 6,
+            sourceEndIndex: 7,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 7,
+            sourceEndIndex: 8,
             value: "-"
           },
           {
             type: "space",
             sourceIndex: 8,
+            sourceEndIndex: 9,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 9,
+            sourceEndIndex: 10,
             value: "2"
           }
         ]
@@ -539,6 +702,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 11,
         value: "calc",
         before: "",
         after: "",
@@ -546,26 +710,31 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 6,
             value: "1"
           },
           {
             type: "space",
             sourceIndex: 6,
+            sourceEndIndex: 7,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 7,
+            sourceEndIndex: 8,
             value: "*"
           },
           {
             type: "space",
             sourceIndex: 8,
+            sourceEndIndex: 9,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 9,
+            sourceEndIndex: 10,
             value: "2"
           }
         ]
@@ -579,6 +748,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 11,
         value: "calc",
         before: "",
         after: "",
@@ -586,26 +756,31 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 6,
             value: "1"
           },
           {
             type: "space",
             sourceIndex: 6,
+            sourceEndIndex: 7,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 7,
+            sourceEndIndex: 8,
             value: "/"
           },
           {
             type: "space",
             sourceIndex: 8,
+            sourceEndIndex: 9,
             value: " "
           },
           {
             type: "word",
             sourceIndex: 9,
+            sourceEndIndex: 10,
             value: "2"
           }
         ]
@@ -619,6 +794,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 9,
         value: "calc",
         before: "",
         after: "",
@@ -626,16 +802,19 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 6,
             value: "1"
           },
           {
             type: "word",
             sourceIndex: 6,
+            sourceEndIndex: 7,
             value: "*"
           },
           {
             type: "word",
             sourceIndex: 7,
+            sourceEndIndex: 8,
             value: "2"
           }
         ]
@@ -649,6 +828,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 9,
         value: "calc",
         before: "",
         after: "",
@@ -656,16 +836,19 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 6,
             value: "1"
           },
           {
             type: "word",
             sourceIndex: 6,
+            sourceEndIndex: 7,
             value: "/"
           },
           {
             type: "word",
             sourceIndex: 7,
+            sourceEndIndex: 8,
             value: "2"
           }
         ]
@@ -679,6 +862,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 34,
         value: "calc",
         before: "",
         after: "",
@@ -686,6 +870,7 @@ var tests = [
           {
             type: "function",
             sourceIndex: 5,
+            sourceEndIndex: 26,
             value: "",
             before: "",
             after: "",
@@ -693,6 +878,7 @@ var tests = [
               {
                 type: "function",
                 sourceIndex: 6,
+                sourceEndIndex: 21,
                 value: "",
                 before: "",
                 after: "",
@@ -700,26 +886,31 @@ var tests = [
                   {
                     type: "word",
                     sourceIndex: 7,
+                    sourceEndIndex: 12,
                     value: "768px"
                   },
                   {
                     type: "space",
                     sourceIndex: 12,
+                    sourceEndIndex: 13,
                     value: " "
                   },
                   {
                     type: "word",
                     sourceIndex: 13,
+                    sourceEndIndex: 14,
                     value: "-"
                   },
                   {
                     type: "space",
                     sourceIndex: 14,
+                    sourceEndIndex: 15,
                     value: " "
                   },
                   {
                     type: "word",
                     sourceIndex: 15,
+                    sourceEndIndex: 20,
                     value: "100vw"
                   }
                 ]
@@ -727,17 +918,18 @@ var tests = [
               {
                 type: "div",
                 sourceIndex: 21,
+                sourceEndIndex: 24,
                 value: "/",
                 before: " ",
                 after: " "
               },
-              { type: "word", sourceIndex: 24, value: "2" }
+              { type: "word", sourceIndex: 24, sourceEndIndex: 25, value: "2" }
             ]
           },
-          { type: "space", sourceIndex: 26, value: " " },
-          { type: "word", sourceIndex: 27, value: "-" },
-          { type: "space", sourceIndex: 28, value: " " },
-          { type: "word", sourceIndex: 29, value: "15px" }
+          { type: "space", sourceIndex: 26, sourceEndIndex: 27, value: " " },
+          { type: "word", sourceIndex: 27, sourceEndIndex: 28, value: "-" },
+          { type: "space", sourceIndex: 28, sourceEndIndex: 29, value: " " },
+          { type: "word", sourceIndex: 29, sourceEndIndex: 33, value: "15px" }
         ]
       }
     ]
@@ -749,40 +941,59 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 18,
         value: "",
         before: "",
         after: "",
         nodes: [
-          { type: "word", sourceIndex: 1, value: "min-width" },
+          {
+            type: "word",
+            sourceIndex: 1,
+            sourceEndIndex: 10,
+            value: "min-width"
+          },
           {
             type: "div",
             sourceIndex: 10,
+            sourceEndIndex: 12,
             value: ":",
             before: "",
             after: " "
           },
-          { type: "word", sourceIndex: 12, value: "700px" }
+          { type: "word", sourceIndex: 12, sourceEndIndex: 17, value: "700px" }
         ]
       },
-      { type: "space", sourceIndex: 18, value: " " },
-      { type: "word", sourceIndex: 19, value: "and" },
-      { type: "space", sourceIndex: 22, value: " " },
+      { type: "space", sourceIndex: 18, sourceEndIndex: 19, value: " " },
+      { type: "word", sourceIndex: 19, sourceEndIndex: 22, value: "and" },
+      { type: "space", sourceIndex: 22, sourceEndIndex: 23, value: " " },
       {
         type: "function",
         sourceIndex: 23,
+        sourceEndIndex: 49,
         value: "",
         before: "",
         after: "",
         nodes: [
-          { type: "word", sourceIndex: 24, value: "orientation" },
+          {
+            type: "word",
+            sourceIndex: 24,
+            sourceEndIndex: 35,
+            value: "orientation"
+          },
           {
             type: "div",
             sourceIndex: 35,
+            sourceEndIndex: 37,
             value: ":",
             before: "",
             after: " "
           },
-          { type: "word", sourceIndex: 37, value: "\\$landscape" }
+          {
+            type: "word",
+            sourceIndex: 37,
+            sourceEndIndex: 48,
+            value: "\\$landscape"
+          }
         ]
       }
     ]
@@ -794,6 +1005,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 40,
         value: "url",
         before: " ",
         after: " ",
@@ -801,6 +1013,7 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 38,
             value: "http://website.com/assets\\)_test"
           }
         ]
@@ -814,6 +1027,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 22,
         value: "fn1",
         before: "",
         after: "",
@@ -821,14 +1035,18 @@ var tests = [
           {
             type: "function",
             sourceIndex: 4,
+            sourceEndIndex: 12,
             value: "fn2",
             before: "",
             after: "",
-            nodes: [{ type: "word", sourceIndex: 8, value: "255" }]
+            nodes: [
+              { type: "word", sourceIndex: 8, sourceEndIndex: 11, value: "255" }
+            ]
           },
           {
             type: "div",
             sourceIndex: 12,
+            sourceEndIndex: 14,
             value: ",",
             before: "",
             after: " "
@@ -836,16 +1054,20 @@ var tests = [
           {
             type: "function",
             sourceIndex: 14,
+            sourceEndIndex: 21,
             value: "fn3",
             before: "",
             after: "",
-            nodes: [{ type: "word", sourceIndex: 18, value: ".2" }]
+            nodes: [
+              { type: "word", sourceIndex: 18, sourceEndIndex: 20, value: ".2" }
+            ]
           }
         ]
       },
       {
         type: "div",
         sourceIndex: 22,
+        sourceEndIndex: 24,
         value: ",",
         before: "",
         after: " "
@@ -853,6 +1075,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 24,
+        sourceEndIndex: 45,
         value: "fn4",
         before: "",
         after: "",
@@ -860,29 +1083,37 @@ var tests = [
           {
             type: "function",
             sourceIndex: 28,
+            sourceEndIndex: 39,
             value: "fn5",
             before: "",
             after: "",
             nodes: [
-              { type: "word", sourceIndex: 32, value: "255" },
+              {
+                type: "word",
+                sourceIndex: 32,
+                sourceEndIndex: 35,
+                value: "255"
+              },
               {
                 type: "div",
                 sourceIndex: 35,
+                sourceEndIndex: 36,
                 value: ",",
                 before: "",
                 after: ""
               },
-              { type: "word", sourceIndex: 36, value: ".2" }
+              { type: "word", sourceIndex: 36, sourceEndIndex: 38, value: ".2" }
             ]
           },
           {
             type: "div",
             sourceIndex: 39,
+            sourceEndIndex: 41,
             value: ",",
             before: "",
             after: " "
           },
-          { type: "word", sourceIndex: 41, value: "fn6" }
+          { type: "word", sourceIndex: 41, sourceEndIndex: 44, value: "fn6" }
         ]
       }
     ]
@@ -894,17 +1125,18 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 11,
         value: "",
         before: "",
         after: "",
         unclosed: true,
         nodes: [
-          { type: "word", sourceIndex: 1, value: "0" },
-          { type: "space", sourceIndex: 2, value: " " },
-          { type: "word", sourceIndex: 3, value: "32" },
-          { type: "space", sourceIndex: 5, value: " " },
-          { type: "word", sourceIndex: 6, value: "word" },
-          { type: "space", sourceIndex: 10, value: " " }
+          { type: "word", sourceIndex: 1, sourceEndIndex: 2, value: "0" },
+          { type: "space", sourceIndex: 2, sourceEndIndex: 3, value: " " },
+          { type: "word", sourceIndex: 3, sourceEndIndex: 5, value: "32" },
+          { type: "space", sourceIndex: 5, sourceEndIndex: 6, value: " " },
+          { type: "word", sourceIndex: 6, sourceEndIndex: 10, value: "word" },
+          { type: "space", sourceIndex: 10, sourceEndIndex: 11, value: " " }
         ]
       }
     ]
@@ -916,6 +1148,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 8,
         value: "",
         before: " ",
         after: "",
@@ -924,6 +1157,7 @@ var tests = [
           {
             type: "function",
             sourceIndex: 2,
+            sourceEndIndex: 8,
             value: "",
             before: " ",
             after: "",
@@ -932,12 +1166,13 @@ var tests = [
               {
                 type: "function",
                 sourceIndex: 4,
+                sourceEndIndex: 7,
                 value: "",
                 before: " ",
                 after: "",
                 nodes: []
               },
-              { type: "space", sourceIndex: 7, value: " " }
+              { type: "space", sourceIndex: 7, sourceEndIndex: 8, value: " " }
             ]
           }
         ]
@@ -948,20 +1183,22 @@ var tests = [
     message: "shouldn't throw an error on unopened function",
     fixture: "0 32 word ) ",
     expected: [
-      { type: "word", sourceIndex: 0, value: "0" },
-      { type: "space", sourceIndex: 1, value: " " },
-      { type: "word", sourceIndex: 2, value: "32" },
-      { type: "space", sourceIndex: 4, value: " " },
-      { type: "word", sourceIndex: 5, value: "word" },
-      { type: "space", sourceIndex: 9, value: " " },
-      { type: "word", sourceIndex: 10, value: ")" },
-      { type: "space", sourceIndex: 11, value: " " }
+      { type: "word", sourceIndex: 0, sourceEndIndex: 1, value: "0" },
+      { type: "space", sourceIndex: 1, sourceEndIndex: 2, value: " " },
+      { type: "word", sourceIndex: 2, sourceEndIndex: 4, value: "32" },
+      { type: "space", sourceIndex: 4, sourceEndIndex: 5, value: " " },
+      { type: "word", sourceIndex: 5, sourceEndIndex: 9, value: "word" },
+      { type: "space", sourceIndex: 9, sourceEndIndex: 10, value: " " },
+      { type: "word", sourceIndex: 10, sourceEndIndex: 11, value: ")" },
+      { type: "space", sourceIndex: 11, sourceEndIndex: 12, value: " " }
     ]
   },
   {
     message: "should process escaped spaces as word in fonts",
     fixture: "Bond\\ 007",
-    expected: [{ type: "word", sourceIndex: 0, value: "Bond\\ 007" }]
+    expected: [
+      { type: "word", sourceIndex: 0, sourceEndIndex: 9, value: "Bond\\ 007" }
+    ]
   },
   {
     message: "should parse double url and comma",
@@ -970,6 +1207,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 16,
         value: "url",
         before: "",
         after: "",
@@ -978,6 +1216,7 @@ var tests = [
       {
         type: "div",
         sourceIndex: 16,
+        sourceEndIndex: 18,
         value: ",",
         before: "",
         after: " "
@@ -985,6 +1224,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 18,
+        sourceEndIndex: 49,
         value: "url",
         before: "",
         after: "",
@@ -992,6 +1232,7 @@ var tests = [
           {
             type: "word",
             sourceIndex: 22,
+            sourceEndIndex: 48,
             value: "http://website.com/img.jpg"
           }
         ]
@@ -1005,6 +1246,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 5,
         value: "url",
         before: "",
         after: "",
@@ -1019,6 +1261,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 6,
         value: "url",
         before: " ",
         after: "",
@@ -1033,6 +1276,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 8,
         value: "url",
         before: "   ",
         after: "",
@@ -1047,6 +1291,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 6,
         value: "url",
         before: "\n",
         after: "",
@@ -1061,6 +1306,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 7,
         value: "url",
         before: "\r\n",
         after: "",
@@ -1075,6 +1321,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 8,
         value: "url",
         before: "\n\n\n",
         after: "",
@@ -1089,6 +1336,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 11,
         value: "url",
         before: "\r\n\r\n\r\n",
         after: "",
@@ -1103,6 +1351,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 16,
         value: "url",
         before: "  \n \t  \r\n  ",
         after: "",
@@ -1114,15 +1363,20 @@ var tests = [
     message: "should parse comments",
     fixture: "/*before*/ 1px /*between*/ 1px /*after*/",
     expected: [
-      { type: "comment", sourceIndex: 0, value: "before" },
-      { type: "space", sourceIndex: 10, value: " " },
-      { type: "word", sourceIndex: 11, value: "1px" },
-      { type: "space", sourceIndex: 14, value: " " },
-      { type: "comment", sourceIndex: 15, value: "between" },
-      { type: "space", sourceIndex: 26, value: " " },
-      { type: "word", sourceIndex: 27, value: "1px" },
-      { type: "space", sourceIndex: 30, value: " " },
-      { type: "comment", sourceIndex: 31, value: "after" }
+      { type: "comment", sourceIndex: 0, sourceEndIndex: 10, value: "before" },
+      { type: "space", sourceIndex: 10, sourceEndIndex: 11, value: " " },
+      { type: "word", sourceIndex: 11, sourceEndIndex: 14, value: "1px" },
+      { type: "space", sourceIndex: 14, sourceEndIndex: 15, value: " " },
+      {
+        type: "comment",
+        sourceIndex: 15,
+        sourceEndIndex: 26,
+        value: "between"
+      },
+      { type: "space", sourceIndex: 26, sourceEndIndex: 27, value: " " },
+      { type: "word", sourceIndex: 27, sourceEndIndex: 30, value: "1px" },
+      { type: "space", sourceIndex: 30, sourceEndIndex: 31, value: " " },
+      { type: "comment", sourceIndex: 31, sourceEndIndex: 42, value: "after" }
     ]
   },
   {
@@ -1132,36 +1386,40 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 26,
         value: "rgba",
         before: " ",
         after: " ",
         nodes: [
-          { type: "word", sourceIndex: 6, value: "0" },
+          { type: "word", sourceIndex: 6, sourceEndIndex: 7, value: "0" },
           {
             type: "div",
             sourceIndex: 7,
+            sourceEndIndex: 9,
             value: ",",
             before: "",
             after: " "
           },
-          { type: "word", sourceIndex: 9, value: "55" },
+          { type: "word", sourceIndex: 9, sourceEndIndex: 11, value: "55" },
           {
             type: "div",
             sourceIndex: 11,
+            sourceEndIndex: 12,
             value: "/",
             before: "",
             after: ""
           },
-          { type: "word", sourceIndex: 12, value: "55" },
+          { type: "word", sourceIndex: 12, sourceEndIndex: 14, value: "55" },
           {
             type: "div",
             sourceIndex: 14,
+            sourceEndIndex: 16,
             value: ",",
             before: "",
             after: " "
           },
-          { type: "word", sourceIndex: 16, value: "0" },
-          { type: "comment", sourceIndex: 17, value: ",.5" }
+          { type: "word", sourceIndex: 16, sourceEndIndex: 17, value: "0" },
+          { type: "comment", sourceIndex: 17, sourceEndIndex: 24, value: ",.5" }
         ]
       }
     ]
@@ -1174,6 +1432,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 33,
         value: "url",
         before: " ",
         after: " ",
@@ -1181,11 +1440,17 @@ var tests = [
           {
             type: "string",
             sourceIndex: 5,
+            sourceEndIndex: 19,
             value: "/demo/bg.png",
             quote: '"'
           },
-          { type: "space", sourceIndex: 19, value: " " },
-          { type: "comment", sourceIndex: 20, value: "comment" }
+          { type: "space", sourceIndex: 19, sourceEndIndex: 20, value: " " },
+          {
+            type: "comment",
+            sourceIndex: 20,
+            sourceEndIndex: 31,
+            value: "comment"
+          }
         ]
       }
     ]
@@ -1198,6 +1463,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 31,
         value: "url",
         before: " ",
         after: " ",
@@ -1205,6 +1471,7 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 29,
             value: "/*comment*/ /demo/bg.png"
           }
         ]
@@ -1219,6 +1486,7 @@ var tests = [
       {
         type: "function",
         sourceIndex: 0,
+        sourceEndIndex: 31,
         value: "url",
         before: " ",
         after: " ",
@@ -1226,6 +1494,7 @@ var tests = [
           {
             type: "word",
             sourceIndex: 5,
+            sourceEndIndex: 29,
             value: "/demo/bg.png /*comment*/"
           }
         ]
@@ -1236,13 +1505,14 @@ var tests = [
     message: "should parse unclosed comments",
     fixture: "/*comment*/ 1px /* unclosed ",
     expected: [
-      { type: "comment", sourceIndex: 0, value: "comment" },
-      { type: "space", sourceIndex: 11, value: " " },
-      { type: "word", sourceIndex: 12, value: "1px" },
-      { type: "space", sourceIndex: 15, value: " " },
+      { type: "comment", sourceIndex: 0, sourceEndIndex: 11, value: "comment" },
+      { type: "space", sourceIndex: 11, sourceEndIndex: 12, value: " " },
+      { type: "word", sourceIndex: 12, sourceEndIndex: 15, value: "1px" },
+      { type: "space", sourceIndex: 15, sourceEndIndex: 16, value: " " },
       {
         type: "comment",
         sourceIndex: 16,
+        sourceEndIndex: 28,
         value: " unclosed ",
         unclosed: true
       }
@@ -1252,66 +1522,129 @@ var tests = [
     message: "should respect escape character",
     fixture: "Hawaii \\35 -0",
     expected: [
-      { type: "word", sourceIndex: 0, value: "Hawaii" },
-      { type: "space", sourceIndex: 6, value: " " },
-      { type: "word", sourceIndex: 7, value: "\\35" },
-      { type: "space", sourceIndex: 10, value: " " },
-      { type: "word", sourceIndex: 11, value: "-0" }
+      { type: "word", sourceIndex: 0, sourceEndIndex: 6, value: "Hawaii" },
+      { type: "space", sourceIndex: 6, sourceEndIndex: 7, value: " " },
+      { type: "word", sourceIndex: 7, sourceEndIndex: 10, value: "\\35" },
+      { type: "space", sourceIndex: 10, sourceEndIndex: 11, value: " " },
+      { type: "word", sourceIndex: 11, sourceEndIndex: 13, value: "-0" }
     ]
   },
   {
     message: "should parse unicode-range (single codepoint)",
     fixture: "U+26",
-    expected: [{ type: "unicode-range", sourceIndex: 0, value: "U+26" }]
+    expected: [
+      {
+        type: "unicode-range",
+        sourceIndex: 0,
+        sourceEndIndex: 4,
+        value: "U+26"
+      }
+    ]
   },
   {
     message: "should parse unicode-range (single codepoint) 2",
     fixture: "U+0-7F",
-    expected: [{ type: "unicode-range", sourceIndex: 0, value: "U+0-7F" }]
+    expected: [
+      {
+        type: "unicode-range",
+        sourceIndex: 0,
+        sourceEndIndex: 6,
+        value: "U+0-7F"
+      }
+    ]
   },
   {
     message: "should parse unicode-range (single codepoint) 3",
     fixture: "U+0-7f",
-    expected: [{ type: "unicode-range", sourceIndex: 0, value: "U+0-7f" }]
+    expected: [
+      {
+        type: "unicode-range",
+        sourceIndex: 0,
+        sourceEndIndex: 6,
+        value: "U+0-7f"
+      }
+    ]
   },
   {
     message: "should parse unicode-range (single codepoint) (lowercase)",
     fixture: "u+26",
-    expected: [{ type: "unicode-range", sourceIndex: 0, value: "u+26" }]
+    expected: [
+      {
+        type: "unicode-range",
+        sourceIndex: 0,
+        sourceEndIndex: 4,
+        value: "u+26"
+      }
+    ]
   },
   {
     message: "should parse unicode-range (codepoint range)",
     fixture: "U+0025-00FF",
-    expected: [{ type: "unicode-range", sourceIndex: 0, value: "U+0025-00FF" }]
+    expected: [
+      {
+        type: "unicode-range",
+        sourceIndex: 0,
+        sourceEndIndex: 11,
+        value: "U+0025-00FF"
+      }
+    ]
   },
   {
     message: "should parse unicode-range (wildcard range)",
     fixture: "U+4??",
-    expected: [{ type: "unicode-range", sourceIndex: 0, value: "U+4??" }]
+    expected: [
+      {
+        type: "unicode-range",
+        sourceIndex: 0,
+        sourceEndIndex: 5,
+        value: "U+4??"
+      }
+    ]
   },
   {
     message: "should parse unicode-range (multiple values)",
     fixture: "U+0025-00FF, U+4??",
     expected: [
-      { type: "unicode-range", sourceIndex: 0, value: "U+0025-00FF" },
-      { type: "div", sourceIndex: 11, value: ",", before: "", after: " " },
-      { type: "unicode-range", sourceIndex: 13, value: "U+4??" }
+      {
+        type: "unicode-range",
+        sourceIndex: 0,
+        sourceEndIndex: 11,
+        value: "U+0025-00FF"
+      },
+      {
+        type: "div",
+        sourceIndex: 11,
+        sourceEndIndex: 13,
+        value: ",",
+        before: "",
+        after: " "
+      },
+      {
+        type: "unicode-range",
+        sourceIndex: 13,
+        sourceEndIndex: 18,
+        value: "U+4??"
+      }
     ]
   },
   {
     message: "should parse invalid unicode-range as word",
     fixture: "U+4??Z",
-    expected: [{ type: "word", sourceIndex: 0, value: "U+4??Z" }]
+    expected: [
+      { type: "word", sourceIndex: 0, sourceEndIndex: 6, value: "U+4??Z" }
+    ]
   },
   {
     message: "should parse invalid unicode-range as word 2",
     fixture: "U+",
-    expected: [{ type: "word", sourceIndex: 0, value: "U+" }]
+    expected: [{ type: "word", sourceIndex: 0, sourceEndIndex: 2, value: "U+" }]
   },
   {
     message: "should parse invalid unicode-range as word 2",
     fixture: "U+Z",
-    expected: [{ type: "word", sourceIndex: 0, value: "U+Z" }]
+    expected: [
+      { type: "word", sourceIndex: 0, sourceEndIndex: 3, value: "U+Z" }
+    ]
   }
 ];
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -1376,7 +1376,7 @@ var tests = [
       { type: "space", sourceIndex: 26, sourceEndIndex: 27, value: " " },
       { type: "word", sourceIndex: 27, sourceEndIndex: 30, value: "1px" },
       { type: "space", sourceIndex: 30, sourceEndIndex: 31, value: " " },
-      { type: "comment", sourceIndex: 31, sourceEndIndex: 42, value: "after" }
+      { type: "comment", sourceIndex: 31, sourceEndIndex: 40, value: "after" }
     ]
   },
   {


### PR DESCRIPTION
Follow-up on #12, needed for stylelint/stylelint#5694

We're implementing range reporting in Stylelint, and as such, need ways to know not just the starting index of a node, but its end index. This isn't as straightforward as looking at the start of the next node, or even the end of the declaration value. Functions may or may not have closing parentheses, which affects where the end is. Nested nodes or functions make it difficult to know downstream precisely where the end of a nested node is.

This PR adds an end index to every token/node. To be as accurate as possible, instead of implementing the feature first, I went through each test case manually and set the expected end indices where they should be. Then, I implemented the feature such that it would make all the test cases pass. This was possible due to how comprehensive the tests are.
