### PR TITLE
Support nested parentheses in url() functions

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -175,22 +175,27 @@ module.exports = function(input) {
       pos = next;
 
       if (name === "url" && code !== singleQuote && code !== doubleQuote) {
-        next -= 1;
-        do {
-          escape = false;
-          next = value.indexOf(")", next + 1);
-          if (~next) {
-            escapePos = next;
-            while (value.charCodeAt(escapePos - 1) === backslash) {
-              escapePos -= 1;
-              escape = !escape;
+        token.unclosed = true;
+        var openParens = 1;
+        for (; next < value.length; next++) {
+          code = value.charCodeAt(next);
+          if (code === backslash) {
+            next += 1;
+          } else if (code === openParentheses) {
+            openParens += 1;
+          } else if (code === closeParentheses) {
+            openParens -= 1;
+            if (openParens === 0) {
+              delete token.unclosed;
+              break;
             }
-          } else {
-            value += ")";
-            next = value.length - 1;
-            token.unclosed = true;
           }
-        } while (escape);
+        }
+        if (token.unclosed) {
+          value += ")";
+          next = value.length - 1;
+        }
+
         // Whitespaces before closed
         whitespacePos = next;
         do {

--- a/test/parse.js
+++ b/test/parse.js
@@ -1247,6 +1247,28 @@ var tests = [
     ]
   },
   {
+    message: "should parse url with nested parentheses",
+    fixture: "url(foo(bar))",
+    expected: [
+      {
+        type: "function",
+        sourceIndex: 0,
+        sourceEndIndex: 13,
+        value: "url",
+        before: "",
+        after: "",
+        nodes: [
+          {
+            type: "word",
+            sourceIndex: 4,
+            sourceEndIndex: 12,
+            value: "foo(bar)"
+          }
+        ]
+      }
+    ]
+  },
+  {
     message: "should parse empty url",
     fixture: "url()",
     expected: [


### PR DESCRIPTION
Although this isn't strictly speaking valid CSS, it's common for
preprocessors and postprocessors to support function calls and similar
constructs within `url()` delimiters, since they appear to be function
calls themselves.

Closes #34
Closes #46