### PR TITLE
fix: incorrectly parsing `url-quotes()` with unquoted argument

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -174,7 +174,11 @@ module.exports = function(input) {
       };
       pos = next;
 
-      if (name === "url" && code !== singleQuote && code !== doubleQuote) {
+      if (
+        (name === "url" || name === "url-prefix") &&
+        code !== singleQuote &&
+        code !== doubleQuote
+      ) {
         next -= 1;
         do {
           escape = false;

--- a/test/parse.js
+++ b/test/parse.js
@@ -1652,6 +1652,52 @@ var tests = [
     expected: [
       { type: "word", sourceIndex: 0, sourceEndIndex: 3, value: "U+Z" }
     ]
+  },
+  {
+    message: "should correctly process url-prefix function",
+    fixture: "url-prefix( http://www.w3.org/Style/ )",
+    expected: [
+      {
+        type: "function",
+        sourceIndex: 0,
+        sourceEndIndex: 38,
+        value: "url-prefix",
+        before: " ",
+        after: " ",
+        nodes: [
+          {
+            type: "word",
+            sourceIndex: 12,
+            sourceEndIndex: 36,
+            value: "http://www.w3.org/Style/"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    message:
+      "should correctly process url-prefix function with quoted first argument",
+    fixture: "url-prefix('http://www.w3.org/Style/')",
+    expected: [
+      {
+        type: "function",
+        sourceIndex: 0,
+        sourceEndIndex: 38,
+        value: "url-prefix",
+        before: "",
+        after: "",
+        nodes: [
+          {
+            type: "string",
+            sourceIndex: 11,
+            sourceEndIndex: 37,
+            value: "http://www.w3.org/Style/",
+            quote: "'"
+          }
+        ]
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Close #88 

All tests in stylelint/stylelint#6711 (importing this PR) pass.

For `url-prefix()`, see the deprecated [`@document`](https://developer.mozilla.org/en-US/docs/Web/CSS/@document).